### PR TITLE
Corrects condition to make Series-6 Controllers work again

### DIFF
--- a/SOURCES/aacraid-1.2.1.60001-fix-Series-6.patch
+++ b/SOURCES/aacraid-1.2.1.60001-fix-Series-6.patch
@@ -1,0 +1,13 @@
+diff --git a/comminit.c b/comminit.c
+index 0c44ba8..d035e18 100644
+--- a/comminit.c
++++ b/comminit.c
+@@ -727,7 +727,7 @@ int aac_init_adapter(struct aac_dev *dev)
+ 		}
+ 	}
+ 
+-	if (aac_is_srcv(dev))
++	if (aac_is_src(dev))
+ 		aac_define_int_mode(dev);
+ 		
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))

--- a/SPECS/microsemi-aacraid.spec
+++ b/SPECS/microsemi-aacraid.spec
@@ -19,9 +19,11 @@
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
 Version: 1.2.1.60001
-Release: %{?xsrel}%{?dist}
+Release: %{?xsrel}.0.fixSeries6.1%{?dist}
 License: GPL
 Source0: microsemi-aacraid-1.2.1.60001.tar.gz
+
+Patch0: aacraid-1.2.1.60001-fix-Series-6.patch
 
 BuildRequires: gcc
 BuildRequires: kernel-devel
@@ -39,6 +41,7 @@ version %{kernel_version}
 
 %prep
 %setup -n %{name}-%{version}
+%patch0 -p1
 %{?_cov_prepare}
 
 %build
@@ -70,5 +73,7 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 
 
 %changelog
+* Thu Nov 28 2024 Christian Großegger <chr.grossegger@gmail.com> - 1.2.1.60001-1.0.fixSeries6.1
+- Fixes Series-6 not working with 60001
 * Mon Sep 19 2022 Zhuangxuan Fei <zhuangxuan.fei@citrix.com> - 1.2.1.60001-1
 - CP-40162: Upgrade microsemi-aacraid driver to version 1.2.1.60001


### PR DESCRIPTION
Adaptec did a refactoring from 52011 to 60001 where they introduced a bug so that the Series-6 Controllers are not working anymore. Instead of checking for Series 6, 7 and 8 they suddenly only are checking for 7 and 8 before a certain function call. This commit restores the original logic - making sure also the Series-6 Controller gets its init-call. Change is only one line of Code. Other controllers are not affected by this change.

See https://github.com/xcp-ng/xcp/issues/472