### PR TITLE
aacraid 1.2.1.60001-2: backport fixes from upstream kernel driver

### DIFF
--- a/SOURCES/0001-aacraid-check-size-values-after-double-fetch-from-us.patch
+++ b/SOURCES/0001-aacraid-check-size-values-after-double-fetch-from-us.patch
@@ -1,0 +1,65 @@
+From fa00c437eef8dc2e7b25f8cd868cfa405fcc2bb3 Mon Sep 17 00:00:00 2001
+From: Dave Carroll <david.carroll@microsemi.com>
+Date: Fri, 5 Aug 2016 13:44:10 -0600
+Subject: [PATCH] aacraid: Check size values after double-fetch from user
+
+In aacraid's ioctl_send_fib() we do two fetches from userspace, one the
+get the fib header's size and one for the fib itself. Later we use the
+size field from the second fetch to further process the fib. If for some
+reason the size from the second fetch is different than from the first
+fix, we may encounter an out-of- bounds access in aac_fib_send(). We
+also check the sender size to insure it is not out of bounds. This was
+reported in https://bugzilla.kernel.org/show_bug.cgi?id=116751 and was
+assigned CVE-2016-6480.
+
+Reported-by: Pengfei Wang <wpengfeinudt@gmail.com>
+Fixes: 7c00ffa31 '[SCSI] 2.6 aacraid: Variable FIB size (updated patch)'
+Cc: stable@vger.kernel.org
+Signed-off-by: Dave Carroll <david.carroll@microsemi.com>
+Reviewed-by: Johannes Thumshirn <jthumshirn@suse.de>
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+ drivers/scsi/aacraid/commctrl.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/commctrl.c b/commctrl.c
+index b381b3718a98..5648b715fed9 100644
+--- a/commctrl.c
++++ b/commctrl.c
+@@ -93,7 +93,7 @@ static int ioctl_send_fib(struct aac_dev * dev, void __user *arg)
+ 	struct fib *fibptr;
+ 	struct hw_fib * hw_fib = (struct hw_fib *)0;
+ 	dma_addr_t hw_fib_pa = (dma_addr_t)0LL;
+-	unsigned size;
++	unsigned int size, osize;
+ 	int retval;
+ 
+ 	if (dev->in_reset) {
+@@ -127,7 +127,8 @@ static int ioctl_send_fib(struct aac_dev * dev, void __user *arg)
+ 	 *	will not overrun the buffer when we copy the memory. Return
+ 	 *	an error if we would.
+ 	 */
+-	size = le16_to_cpu(kfib->header.Size) + sizeof(struct aac_fibhdr);
++	osize = size = le16_to_cpu(kfib->header.Size) +
++		sizeof(struct aac_fibhdr);
+ 	if (size < le16_to_cpu(kfib->header.SenderSize))
+ 		size = le16_to_cpu(kfib->header.SenderSize);
+ 	if (size > dev->max_fib_size) {
+@@ -159,6 +159,14 @@ static int ioctl_send_fib(struct aac_dev * dev, void __user *arg)
+ 		goto cleanup;
+ 	}
+ 
++	/* Sanity check the second copy */
++	if ((osize != le16_to_cpu(kfib->header.Size) +
++		sizeof(struct aac_fibhdr))
++		|| (size < le16_to_cpu(kfib->header.SenderSize))) {
++		retval = -EINVAL;
++		goto cleanup;
++	}
++
+ 	if (kfib->header.Command == cpu_to_le16(TakeABreakPt)) {
+ 		aac_adapter_interrupt(dev);
+ 		/*
+-- 
+2.51.0
+

--- a/SOURCES/0002-aacraid-prevent-invalid-pointer-dereference.patch
+++ b/SOURCES/0002-aacraid-prevent-invalid-pointer-dereference.patch
@@ -1,0 +1,39 @@
+From b4789b8e6be3151a955ade74872822f30e8cd914 Mon Sep 17 00:00:00 2001
+From: Mahesh Rajashekhara <Mahesh.Rajashekhara@pmcs.com>
+Date: Thu, 31 Oct 2013 14:01:02 +0530
+Subject: [PATCH] aacraid: prevent invalid pointer dereference
+
+It appears that driver runs into a problem here if fibsize is too small
+because we allocate user_srbcmd with fibsize size only but later we
+access it until user_srbcmd->sg.count to copy it over to srbcmd.
+
+It is not correct to test (fibsize < sizeof(*user_srbcmd)) because this
+structure already includes one sg element and this is not needed for
+commands without data.  So, we would recommend to add the following
+(instead of test for fibsize == 0).
+
+Signed-off-by: Mahesh Rajashekhara <Mahesh.Rajashekhara@pmcs.com>
+Reported-by: Nico Golde <nico@ngolde.de>
+Reported-by: Fabian Yamaguchi <fabs@goesec.de>
+Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
+---
+ drivers/scsi/aacraid/commctrl.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/scsi/aacraid/commctrl.c b/drivers/scsi/aacraid/commctrl.c
+index d85ac1a9d2c0..fbcd48d0bfc3 100644
+--- a/commctrl.c
++++ b/commctrl.c
+@@ -676,7 +676,8 @@ static int aac_send_raw_srb(struct aac_dev* dev, void __user * arg)
+ 		goto cleanup;
+ 	}
+ 
+-	if (fibsize > (dev->max_fib_size - sizeof(struct aac_fibhdr))) {
++	if ((fibsize < (sizeof(struct user_aac_srb) - sizeof(struct user_sgentry))) ||
++	    (fibsize > (dev->max_fib_size - sizeof(struct aac_fibhdr)))) {
+ 		rcode = -EINVAL;
+ 		goto cleanup;
+ 	}
+-- 
+2.51.0
+

--- a/SOURCES/0003-scsi-aacraid-fix-leak-of-data-from-stack-back-to-use.patch
+++ b/SOURCES/0003-scsi-aacraid-fix-leak-of-data-from-stack-back-to-use.patch
@@ -1,0 +1,35 @@
+From 5cc973f09e21b5a2f746307641879bc9f1da623b Mon Sep 17 00:00:00 2001
+From: Colin Ian King <colin.king@canonical.com>
+Date: Mon, 15 May 2017 15:56:05 +0100
+Subject: [PATCH] scsi: aacraid: fix leak of data from stack back to userspace
+
+The fields sense_data_size and sense_data are unitialized garbage from
+the stack and are being copied back to userspace.  Fix this leak of
+stack information by ensuring they are zero'd.
+
+Detected by CoverityScan, CID#1435473 ("Uninitialized scalar variable")
+
+Fixes: 423400e64d377 ("scsi: aacraid: Include HBA direct interface")
+Signed-off-by: Colin Ian King <colin.king@canonical.com>
+Acked-by: Dave Carroll <david.carroll@microsemi.com>
+Signed-off-by: Martin K. Petersen <martin.petersen@oracle.com>
+---
+ drivers/scsi/aacraid/commctrl.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/drivers/scsi/aacraid/commctrl.c b/drivers/scsi/aacraid/commctrl.c
+index 106b9332f718..6bb6ed48e31d 100644
+--- a/commctrl.c
++++ b/commctrl.c
+@@ -1118,6 +1118,8 @@ static int aac_send_raw_srb(struct aac_dev* dev, void __user * arg)
+ 			reply.srb_status = SRB_STATUS_SUCCESS;
+ 			reply.scsi_status = 0;
+ 			reply.data_xfer_length = byte_count;
++			reply.sense_data_size = 0;
++			memset(reply.sense_data, 0, AAC_SENSE_BUFFERSIZE);
+ 		} else {
+ 			reply.srb_status = err->service_response;
+ 			reply.scsi_status = err->status;
+-- 
+2.51.0
+

--- a/SOURCES/0004-aacraid-replace-pci_alloc_consistent-with-dma_alloc_.patch
+++ b/SOURCES/0004-aacraid-replace-pci_alloc_consistent-with-dma_alloc_.patch
@@ -1,0 +1,145 @@
+aacraid: replace pci_alloc_consistent with dma_alloc_coherent
+
+pci_alloc_consistent() and pci_free_consistent() were removed in
+kernel 5.18 in favour of the generic DMA API. Replace all remaining
+direct call sites and collapse the aac_pci_alloc_consistent() /
+aac_pci_free_consistent() wrappers so they unconditionally delegate to
+dma_alloc_coherent() / dma_free_coherent() regardless of architecture.
+
+Critically, pci_alloc_consistent() internally passed GFP_ATOMIC to the
+DMA allocator. GFP_ATOMIC is non-sleeping and cannot trigger memory
+compaction or reclaim, making it unreliable for large allocations. On
+XEN guests this is especially problematic: the balloon driver
+continuously returns pages to the hypervisor, fragmenting the guest's
+physical address space and making large contiguous allocations nearly
+impossible under GFP_ATOMIC.
+
+The aacraid driver is particularly exposed because fib_map_alloc()
+performs a single contiguous DMA allocation for the entire FIB pool:
+
+  size = (max_cmd_size + sizeof(aac_fib_xporthdr))
+         * (can_queue + AAC_NUM_MGT_FIB)
+
+With max_cmd_size=2048, sizeof(xporthdr)=32, AAC_NUM_MGT_FIB=8, and
+can_queue read from firmware at up to AAC_NUM_IO_FIB (1016), this
+evaluates to 2080 * 1024 = 2,129,920 bytes (over 2 MB) in a single
+GFP_ATOMIC allocation. At that size, GFP_ATOMIC will fail outright on
+any fragmented system and reliably on XEN. Switching to GFP_KERNEL
+allows the allocator to sleep, compact, and retry, making this
+allocation dependable regardless of memory pressure.
+
+Affected files:
+  aacraid.h  - remove CONFIG_ARM64 guard, fix aac_pci_free_consistent
+  aachba.c   - direct calls inside __VMKLNX__ guard
+  commsup.c  - direct pci_free_consistent in aac_fib_map_free
+  frey.c     - direct calls in frey POST path
+
+Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f481973d5efdb63b7c6ca6b0ecd2b8462556a461
+Signed-off-by: Julian Vetter <julian.vetter@vates.tech>
+---
+diff --color -Naur aacraid-1.2.1-60001.old/aacraid.h aacraid-1.2.1-60001/aacraid.h
+--- aacraid-1.2.1-60001.old/aacraid.h	2020-11-26 08:45:08.000000000 +0100
++++ aacraid-1.2.1-60001/aacraid.h	2026-02-20 14:34:58.665630069 +0100
+@@ -3731,25 +3731,18 @@
+ extern int aac_check_reset;
+ extern int aac_fib_dump;
+
+-#if defined(CONFIG_ARM64)
+ static inline void *
+ aac_pci_alloc_consistent(struct pci_dev *hwdev, size_t size,
+ 		     dma_addr_t *dma_handle) {
+ 	return dma_alloc_coherent(hwdev == NULL ? NULL : &hwdev->dev, size, dma_handle, GFP_KERNEL);
+ }
+-#else
+-static inline void *
+-aac_pci_alloc_consistent(struct pci_dev *hwdev, size_t size,
+-		     dma_addr_t *dma_handle) {
+-	return pci_alloc_consistent(hwdev, size, dma_handle);
+-}
+-#endif
+
+ static inline void
+ aac_pci_free_consistent(struct pci_dev *hwdev, size_t size,
+ 			void *vaddr, dma_addr_t dma_handle)
+ {
+-	pci_free_consistent(hwdev, size, vaddr, dma_handle);
++	dma_free_coherent(hwdev == NULL ? NULL : &hwdev->dev, size,
++			  vaddr, dma_handle);
+ }
+
+ #endif
+diff --color -Naur aacraid-1.2.1-60001.old/aachba.c aacraid-1.2.1-60001/aachba.c
+--- aacraid-1.2.1-60001.old/aachba.c	2020-11-26 08:45:08.000000000 +0100
++++ aacraid-1.2.1-60001/aachba.c	2026-02-20 14:43:52.063797501 +0100
+@@ -2763,7 +2763,7 @@
+
+ #if defined(__VMKLNX__)
+ 	/* allocate DMA buffer for response */
+-	lresp = (void *) pci_alloc_consistent(dev->pdev, xfer_len, &addr);
++	lresp = dma_alloc_coherent(&dev->pdev->dev, xfer_len, &addr, GFP_KERNEL);
+ 	if(!lresp) {
+ 		aac_err(dev,"aac_pci_alloc_consistent failed\n");
+ 		rcode = -ENOMEM;
+@@ -2831,7 +2831,7 @@
+
+ bmic_error:
+ #if defined(__VMKLNX__)
+-	pci_free_consistent(dev->pdev, xfer_len, lresp, addr);
++	dma_free_coherent(&dev->pdev->dev, xfer_len, lresp, addr);
+ #else
+ 	dma_unmap_single(&dev->pdev->dev, addr, xfer_len, DMA_BIDIRECTIONAL);
+ #endif
+diff --color -Naur aacraid-1.2.1-60001.old/commsup.c aacraid-1.2.1-60001/commsup.c
+--- aacraid-1.2.1-60001.old/commsup.c	2020-11-26 08:45:08.000000000 +0100
++++ aacraid-1.2.1-60001/commsup.c	2026-02-20 14:37:38.295056556 +0100
+@@ -260,7 +260,7 @@
+ 	fib_size = dev->max_fib_size + sizeof(struct aac_fib_xporthdr);
+ 	alloc_size = fib_size * num_fibs + ALIGN32 - 1;
+
+-	pci_free_consistent(dev->pdev, alloc_size, dev->hw_fib_va,
++	dma_free_coherent(&dev->pdev->dev, alloc_size, dev->hw_fib_va,
+ 							dev->hw_fib_pa);
+ 	dev->hw_fib_va = NULL;
+ 	dev->hw_fib_pa = 0;
+diff --color -Naur aacraid-1.2.1-60001.old/frey.c aacraid-1.2.1-60001/frey.c
+--- aacraid-1.2.1-60001.old/frey.c	2020-11-26 08:45:08.000000000 +0100
++++ aacraid-1.2.1-60001/frey.c	2026-02-20 14:43:54.647885708 +0100
+@@ -354,17 +354,17 @@
+ #if (((__GNUC__ * 10000) + (__GNUC_MINOR__ * 100) + __GNUC_PATCHLEVEL__) <= 400002)
+ 		baddr = 0;
+ #endif
+-		buffer = pci_alloc_consistent(dev->pdev, 512, &baddr);
++		buffer = dma_alloc_coherent(&dev->pdev->dev, 512, &baddr, GFP_KERNEL);
+ 		ret = -2;
+ 		if (unlikely(buffer == NULL))
+ 			return ret;
+ #if (((__GNUC__ * 10000) + (__GNUC_MINOR__ * 100) + __GNUC_PATCHLEVEL__) <= 400002)
+ 		paddr = 0;
+ #endif
+-		post = pci_alloc_consistent(dev->pdev,
+-		  sizeof(struct POSTSTATUS), &paddr);
++		post = dma_alloc_coherent(&dev->pdev->dev,
++		  sizeof(struct POSTSTATUS), &paddr, GFP_KERNEL);
+ 		if (unlikely(post == NULL)) {
+-			pci_free_consistent(dev->pdev, 512, buffer, baddr);
++			dma_free_coherent(&dev->pdev->dev, 512, buffer, baddr);
+ 			return ret;
+ 		}
+ 		memset(buffer, 0, 512);
+@@ -373,14 +373,14 @@
+ 		frey_writel0(dev, IMR0, paddr);
+ 		frey_sync_cmd(dev, COMMAND_POST_RESULTS, baddr, 0, 0, 0, 0, 0,
+ 		  NULL, NULL, NULL, NULL, NULL);
+-		pci_free_consistent(dev->pdev, sizeof(struct POSTSTATUS),
++		dma_free_coherent(&dev->pdev->dev, sizeof(struct POSTSTATUS),
+ 		  post, paddr);
+ 		if (likely((buffer[0] == '0') && ((buffer[1] == 'x') || (buffer[1] == 'X')))) {
+ 			ret = (buffer[2] <= '9') ? (buffer[2] - '0') : (buffer[2] - 'A' + 10);
+ 			ret <<= 4;
+ 			ret += (buffer[3] <= '9') ? (buffer[3] - '0') : (buffer[3] - 'A' + 10);
+ 		}
+-		pci_free_consistent(dev->pdev, 512, buffer, baddr);
++		dma_free_coherent(&dev->pdev->dev, 512, buffer, baddr);
+ 		return ret;
+ 	}
+ 	/*

--- a/SOURCES/0005-aacraid-replace-aac_is_srcv-with-aac_is_src.patch
+++ b/SOURCES/0005-aacraid-replace-aac_is_srcv-with-aac_is_src.patch
@@ -1,0 +1,58 @@
+aacraid: replace aac_is_srcv() with aac_is_src()
+
+aac_is_srcv() checks only for the SRCv variant of the SRC controller
+family. aac_is_src() checks for the whole SRC family (both SRC and
+SRCv) and is therefore the correct predicate to use when deciding
+whether to apply SRC-generation behaviour such as defining the
+interrupt mode or switching back to INTx.
+All four call sites that used aac_is_srcv() for this purpose are
+updated to aac_is_src(). The aac_is_srcv() definition itself is left
+in aacraid.h for now as it is still referenced by other driver logic.
+
+Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=395e5df79a9588abf1099ea746f11872c9086252
+Link: https://lore.kernel.org/all/20190627161408.10295-1-khorenko@virtuozzo.com/
+Signed-off-by: Julian Vetter <julian.vetter@vates.tech>
+---
+diff --color -Naur microsemi-aacraid-1.2.1.60001.old/comminit.c microsemi-aacraid-1.2.1.60001/comminit.c
+--- microsemi-aacraid-1.2.1.60001.old/comminit.c	2020-12-18 15:53:02.000000000 +0100
++++ microsemi-aacraid-1.2.1.60001/comminit.c	2026-03-20 13:58:49.842159021 +0100
+@@ -437,7 +437,7 @@
+ 	if (status != -ERESTARTSYS)
+ 		aac_fib_free(fibctx);
+ 
+-	if (aac_is_srcv(dev) && dev->msix_enabled)
++	if (aac_is_src(dev) && dev->msix_enabled)
+ 		aac_set_intx_mode(dev);
+ 
+ 	return status;
+@@ -699,7 +699,7 @@
+ 		dev->max_fib_size = status[1] & 0xFFE0;	/* multiple of 32 for PMC */
+ 		host->sg_tablesize = status[2] >> 16;
+ 		dev->sg_tablesize = status[2] & 0xFFFF;
+-		if (aac_is_srcv(dev)) {
++		if (aac_is_src(dev)) {
+ #if (defined(AAC_CITRIX))
+ 			if (host->can_queue > 248)
+ 				host->can_queue = 248;
+@@ -727,7 +727,7 @@
+ 		}
+ 	}
+ 
+-	if (aac_is_srcv(dev))
++	if (aac_is_src(dev))
+ 		aac_define_int_mode(dev);
+ 		
+ #if (LINUX_VERSION_CODE >= KERNEL_VERSION(4,11,0))
+diff --color -Naur microsemi-aacraid-1.2.1.60001.old/linit.c microsemi-aacraid-1.2.1.60001/linit.c
+--- microsemi-aacraid-1.2.1.60001.old/linit.c	2020-12-18 15:53:02.000000000 +0100
++++ microsemi-aacraid-1.2.1.60001/linit.c	2026-03-20 14:01:01.985023849 +0100
+@@ -3447,7 +3447,7 @@
+ 	aac_adapter_disable_int(dev);
+ 	aac_adapter_enable_int(dev);
+ 
+-	if (aac_is_srcv(dev))
++	if (aac_is_src(dev))
+ 		aac_define_int_mode(dev);
+ 
+ 	if (dev->msix_enabled)
+

--- a/SOURCES/0006-aacraid-fix-wrong-aac_fib_complete-ordering-in-ioctl.patch
+++ b/SOURCES/0006-aacraid-fix-wrong-aac_fib_complete-ordering-in-ioctl.patch
@@ -1,0 +1,39 @@
+aacraid: fix wrong aac_fib_complete() ordering in ioctl_send_fib
+
+aac_fib_complete() was called before the return value of aac_fib_send()
+was checked. A send error therefore caused aac_fib_complete() to run on
+a FIB that was never successfully sent, which could mask the real error.
+
+Fix the ordering: check retval first, bail early on failure, and only
+call aac_fib_complete() when the send succeeded.
+
+Equivalent to the fix introduced in upstream commit
+7c00ffa314bf0fb0e23858bbebad33b48b6abbb9
+('[SCSI] 2.6 aacraid: Variable FIB size (updated patch)').
+
+Link: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=7c00ffa314bf0fb0e23858bbebad33b48b6abbb9
+Signed-off-by: Julian Vetter <julian.vetter@vates.tech>
+---
+diff --color -Naur microsemi-aacraid-1.2.1.60001.old/commctrl.c microsemi-aacraid-1.2.1.60001/commctrl.c
+--- microsemi-aacraid-1.2.1.60001.old/commctrl.c	2020-12-18 15:53:02.000000000 +0100
++++ microsemi-aacraid-1.2.1.60001/commctrl.c	2026-03-20 12:00:00.000000000 +0100
+@@ -183,14 +183,15 @@
+ 			  kfib->header.Command,
+ 			  le16_to_cpu(kfib->header.Size), retval);
+
+-		if (aac_fib_complete(fibptr) != 0) {
+-			if (!retval)
+-				retval = -EINVAL;
++		if (retval) {
+ 			goto cleanup;
+ 		}
+-		if (retval) {
++
++		if (aac_fib_complete(fibptr) != 0) {
++			retval = -EINVAL;
+ 			goto cleanup;
+ 		}
++
+ 	}
+ 	/*
+ 	 *	Make sure that the size returned by the adapter (which includes

--- a/SPECS/microsemi-aacraid.spec
+++ b/SPECS/microsemi-aacraid.spec
@@ -19,9 +19,17 @@
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}
 Version: 1.2.1.60001
-Release: %{?xsrel}%{?dist}
+Release: %{?xsrel}.1%{?dist}
 License: GPL
 Source0: microsemi-aacraid-1.2.1.60001.tar.gz
+
+# XCP-ng patches
+Patch1001: 0001-aacraid-check-size-values-after-double-fetch-from-us.patch
+Patch1002: 0002-aacraid-prevent-invalid-pointer-dereference.patch
+Patch1003: 0003-scsi-aacraid-fix-leak-of-data-from-stack-back-to-use.patch
+Patch1004: 0004-aacraid-replace-pci_alloc_consistent-with-dma_alloc_.patch
+Patch1005: 0005-aacraid-replace-aac_is_srcv-with-aac_is_src.patch
+Patch1006: 0006-aacraid-fix-wrong-aac_fib_complete-ordering-in-ioctl.patch
 
 BuildRequires: gcc
 BuildRequires: kernel-devel
@@ -39,6 +47,7 @@ version %{kernel_version}
 
 %prep
 %setup -n %{name}-%{version}
+%autopatch -p1
 %{?_cov_prepare}
 
 %build
@@ -70,5 +79,14 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 
 
 %changelog
+* Thu Mar 06 2026 Julian Vetter <julian.vetter@vates.tech> - 1.2.1.60001-1.1
+- Replace pci_alloc_consistent/pci_free_consistent with dma_alloc_coherent/
+  dma_free_coherent to avoid GFP_ATOMIC failures on XEN guests (CVE-2016-6480)
+- Replace aac_is_srcv() with aac_is_src() at all relevant call sites
+- Fix TOCTOU race in ioctl_send_fib (CVE-2016-6480, backport of fa00c437)
+- Fix wrong aac_fib_complete() error-handling order in ioctl_send_fib
+- Add missing lower-bound check on fibsize in aac_send_raw_srb (backport of b4789b8)
+- Fix uninitialised sense_data leak in fast-response path (backport of 5cc973f)
+
 * Mon Sep 19 2022 Zhuangxuan Fei <zhuangxuan.fei@citrix.com> - 1.2.1.60001-1
 - CP-40162: Upgrade microsemi-aacraid driver to version 1.2.1.60001


### PR DESCRIPTION
Add three patches against the Microsemi out-of-tree aacraid 1.2.1.60001 source tree, all equivalent to changes present in the upstream Linux kernel driver (drivers/scsi/aacraid/, kernel 4.19.19).

**0001 - Replace pci_alloc_consistent with dma_alloc_coherent**
  `pci_alloc_consistent()` was removed in kernel 5.18. More importantly, it used `GFP_ATOMIC` internally, making it unreliable for the large contiguous FIB pool allocation performed by `fib_map_alloc()`. With default firmware settings, that allocation reaches ~2 MB (2080 * 1024 bytes), which `GFP_ATOMIC` cannot satisfy on a fragmented system. On XEN guests, where the balloon driver fragments physical memory, this allocation fails consistently. Switching to `dma_alloc_coherent()` with `GFP_KERNEL` allows the allocator to sleep and compact memory, making the allocation reliable.

**0002 - Replace aac_is_srcv() with aac_is_src()**
  `aac_is_srcv()` checks only for the SRCv controller variant. The correct predicate for applying SRC-generation behaviour (defining interrupt mode, switching back to INTx) is `aac_is_src()`, which covers the full SRC family. Fixes four call sites in `comminit.c` and `linit.c`.

**0003 - Fix security and correctness issues in ioctl paths**
  - TOCTOU in `ioctl_send_fib`: header.Size is read before a DMA buffer may be reallocated, then the full FIB is copied again. A racing caller could change the size between copies. Fix by saving osize before the allocation and validating it after the second copy.
  - Wrong `aac_fib_complete()` ordering: a failed `aac_fib_send()` could be masked by a successful completion check. Fix by checking retval first.
  - Missing lower-bound fibsize check in `aac_send_raw_srb`: an undersized fibsize causes out-of-bounds field accesses.
  - Uninitialised `sense_data` in the fast-response path leaks kernel stack contents to userspace.
  - fibctx AIF wakeups used struct completion (edge-triggered), so multiple arriving FIBs before the waiter woke up would lose notifications. Switch to struct semaphore as upstream does.